### PR TITLE
fix: resolve title conflict between The Middle and Malcolm in the Middle

### DIFF
--- a/fscorrupt/show-list.yml
+++ b/fscorrupt/show-list.yml
@@ -154,6 +154,7 @@ collections:
       limit: 50
       all:
         title.is: "The Middle"
+        title.not: "Malcolm mittendrin"
     sort_title: " !AC<<title>>"
 
   # Malcolm in the Middle (Custom due to a bug with "The Middle")
@@ -166,6 +167,7 @@ collections:
       limit: 50
       all:
         title.is: "Malcolm mittendrin"
+        title.not: "The Middle"
     sort_title: " !AC<<title>>"
 
   # House (Custom due to the german title "Dr. House")


### PR DESCRIPTION
This change fixes a bug where episodes from "Malcolm in the Middle" (Malcolm mittendrin) and "The Middle" were incorrectly overlapping in Plex Meta Manager due to title search overlaps. By adding explicit `title.not` filters to both collections, the episode pools are correctly separated.

---
*PR created automatically by Jules for task [14475516647657175497](https://jules.google.com/task/14475516647657175497) started by @ladywhiskers*