### PR TITLE
🧹 [code health] Remove commented-out 'It Really Happened' genre collection due to timeout risk

### DIFF
--- a/nwithan8/collections/genres/movies.yml
+++ b/nwithan8/collections/genres/movies.yml
@@ -119,17 +119,6 @@ collections:
     visible_home: false  # Not advertised on the home page
     visible_shared: false  # Not advertised on the home page
 
-  # TODO: Might time out due to size
-  # "🧑 It Really Happened":
-  #  template: { name: Genre }
-  #  summary: "These people actually existed."
-  #  trakt_list:
-  #    - https://trakt.tv/users/majeed_pk/lists/biographies
-  #  collection_order: random
-  #  visible_library: true
-  #  visible_home: true
-  #  visible_shared: true
-
   "🌿 What Is Life Anyway?":
     template: { name: Genre }
     summary: "The best existential movies of all time"


### PR DESCRIPTION
🎯 **What:** The commented-out genre collection `"🧑 It Really Happened"` in `nwithan8/collections/genres/movies.yml` was evaluated and safely deleted.
💡 **Why:** The comment indicated a potential performance issue (`Might time out due to size`). Simply uncommenting it would risk introducing timeouts during runs since community-sourced Trakt lists can grow very large and be slow to process. By completely removing the dead code block, we improve readability, remove technical debt, and ensure the configuration file remains clean.
✅ **Verification:** I viewed the changes via `git diff` to ensure only the target block was removed. I validated the syntax of the modified YAML file using `ruby -ryaml -e "YAML.load_file('nwithan8/collections/genres/movies.yml')"` and confirmed it is still well-formed.
✨ **Result:** The code health issue is resolved, improving maintainability without risking the introduction of a new issue.

---
*PR created automatically by Jules for task [14686672752631971976](https://jules.google.com/task/14686672752631971976) started by @ladywhiskers*