### PR TITLE
chore: Update 31 Days of Horror Trakt list to 2024

### DIFF
--- a/nwithan8/collections/holidays/movies.yml
+++ b/nwithan8/collections/holidays/movies.yml
@@ -181,7 +181,7 @@ collections:
     summary: "Don't be scared, it's just a movie."
     collection_order: random
     trakt_list:
-      - https://trakt.tv/users/lish408/lists/31-days-of-horror-2023  # TODO: Change annually
+      - https://trakt.tv/users/lish408/lists/31-days-of-horror-2024  # TODO: Change annually
 
   "🍬 Trick or Treat":
     schedule: range(10/01-11/01)


### PR DESCRIPTION
Updates the Trakt list URL for the "31 Days of Horror" collection in `nwithan8/collections/holidays/movies.yml` to the 2024 version as requested. The `# TODO: Change annually` comment has been left intact to ensure it is updated next year as well.

---
*PR created automatically by Jules for task [17192204519475737137](https://jules.google.com/task/17192204519475737137) started by @ladywhiskers*