### PR TITLE
Update Oscar Nominees Trakt list to 2024

### DIFF
--- a/nwithan8/collections/awards/movies.yml
+++ b/nwithan8/collections/awards/movies.yml
@@ -271,7 +271,7 @@ collections:
                 level: "++++" }
     trakt_list:
       # TODO: NEED TO REPLACE MANUALLY
-      - https://trakt.tv/users/jcbwoldseth/lists/oscar-race-2023
+      - https://trakt.tv/users/jcbwoldseth/lists/oscar-race-2024
     collection_order: random
     schedule:
       - yearly(02/01)


### PR DESCRIPTION
Manually updated the Trakt list URL for "This Year's Oscar Nominees" in `nwithan8/collections/awards/movies.yml` from the 2023 list to the 2024 list as requested by the task.

---
*PR created automatically by Jules for task [5217119992562721477](https://jules.google.com/task/5217119992562721477) started by @ladywhiskers*