### PR TITLE
Populate "This Year's Best Picture Nominees" collection manually

### DIFF
--- a/nwithan8/collections/awards/movies.yml
+++ b/nwithan8/collections/awards/movies.yml
@@ -94,7 +94,17 @@ collections:
   # This current year's Best Picture Oscar nominees
   # Only visible on home screen during Oscar season
   "🎬 This Year's Best Picture Nominees":
-    # TODO: NEED TO BUILD MANUALLY
+    tmdb_movie:
+      - 49046
+      - 76600
+      - 674324
+      - 614934
+      - 545611
+      - 804095
+      - 817758
+      - 361743
+      - 497828
+      - 777245
     template: { name: Award,
                 level: "++++++" }
     summary: "Who will take home the trophy?"


### PR DESCRIPTION
Populate "This Year's Best Picture Nominees" collection manually

Addresses the TODO comment in `nwithan8/collections/awards/movies.yml` by manually building the list of Best Picture nominees for the 95th Academy Awards (films released in 2022, awarded in 2023). Added the TMDB IDs for the 10 nominated films using the `tmdb_movie` builder.

---
*PR created automatically by Jules for task [7712515039462699492](https://jules.google.com/task/7712515039462699492) started by @ladywhiskers*